### PR TITLE
fix: revert app name to "Task Manager" in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Task Manager Pro",
+  "name": "Task Manager",
   "short_name": "TaskManager",
   "description": "Complete task and habit management system with gamification",
   "start_url": "./index.html",


### PR DESCRIPTION
This pull request makes a minor update to the application name in the `manifest.json` file. The name has been changed from "Task Manager Pro" to "Task Manager".